### PR TITLE
关闭自动领取派遣委托的按钮

### DIFF
--- a/BetterGenshinImpact/Core/Config/PathingPartyConfig.cs
+++ b/BetterGenshinImpact/Core/Config/PathingPartyConfig.cs
@@ -117,6 +117,12 @@ public partial class PathingPartyConfig : ObservableObject
     //在连续执行时是否隐藏
     [ObservableProperty]
     private bool _hideOnRepeat = false;
+
+    /// <summary>
+    /// 关闭地图追踪过程中的自动领取派遣奖励
+    /// </summary>
+    [ObservableProperty]
+    private bool _disableAutoFetchDispatch = false;  // 默认关闭
     
     //执行周期配置
     [ObservableProperty]

--- a/BetterGenshinImpact/GameTask/AutoFight/AutoFightTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/AutoFightTask.cs
@@ -1629,7 +1629,8 @@ public class AutoFightTask : ISoloTask
                                             }
                                             else
                                             {
-                                                bool isSimilar = IsPixelSimilar(bloodtRect.SrcMat.At<Vec3b>(1, 1), bloodtRect.SrcMat.At<Vec3b>(2, 2), 2);
+                                                bool isSimilar = IsPixelSimilar(bloodtRect.SrcMat.At<Vec3b>(1, 1), bloodtRect.SrcMat.At<Vec3b>(3, 3), 2);
+                                                // Logger.LogWarning("自动吃药：检测到血量颜色异常，是否与之前的血量颜色相似：{isSimilar}", isSimilar);
                                                 if (isSimilar)
                                                 {
                                                     redBlood = false;

--- a/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
@@ -2099,7 +2099,8 @@ public class PathExecutor
                 // 自动疾跑
                 if (distance > 20 && PartyConfig.AutoRunEnabled)
                 {
-                    if (Math.Abs((fastModeColdTime - DateTime.UtcNow).TotalMilliseconds) > 2500) //冷却时间2.5s，回复体力用
+                    var dushTime = nextDistance > 90 ? 3500 : 2500;
+                    if (Math.Abs((fastModeColdTime - DateTime.UtcNow).TotalMilliseconds) > dushTime) //冷却时间2.5s，回复体力用
                     {
                         fastModeColdTime = DateTime.UtcNow;
                         Simulation.SendInput.SimulateAction(GIActions.SprintMouse);
@@ -2260,7 +2261,7 @@ public class PathExecutor
                 SuccessFight++;
             }
 
-            if (PartyConfig.QuicklySkip && (_lastWaypoint?.Action == ActionEnum.Fight.Code || waypoint.Action == ActionEnum.Fight.Code))
+            if (PartyConfig.QuicklySkip && (_lastWaypoint?.Action == ActionEnum.Fight.Code || waypoint.Action == ActionEnum.Fight.Code || nextWaypoint?.Action == ActionEnum.Fight.Code))
             {
                 if (nextWaypoint?.Type != WaypointType.Teleport.Code)
                 {

--- a/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
@@ -1057,6 +1057,12 @@ public class PathExecutor
     /// <returns>是否可以领取派遣奖励</returns>
     private async Task<bool> TryGetExpeditionRewardsDispatch(TpTask? tpTask = null)
     {
+        // 检查配置组设置：是否禁用自动领取派遣奖励
+        if (PartyConfig?.DisableAutoFetchDispatch == true)
+        {
+            return false;
+        }
+
         if (tpTask == null)
         {
             tpTask = new TpTask(ct);

--- a/BetterGenshinImpact/View/Pages/View/ScriptGroupConfigView.xaml
+++ b/BetterGenshinImpact/View/Pages/View/ScriptGroupConfigView.xaml
@@ -524,6 +524,30 @@
                             <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
                         <ui:TextBlock Grid.Row="0"
+                                        Grid.Column="0"
+                                        FontTypography="Body"
+                                        Text="关闭地图追踪过程中的自动领取派遣奖励"
+                                        TextWrapping="Wrap" />
+                        <ui:TextBlock Grid.Row="1"
+                                        Grid.Column="0"
+                                        Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                        Text="开启后，在大地图传送中，不会自动领取派遣奖励"
+                                        TextWrapping="Wrap" />
+                        <ui:ToggleSwitch Grid.Row="0"
+                                            Grid.RowSpan="2"
+                                            Grid.Column="1"
+                                            IsChecked="{Binding PathingConfig.DisableAutoFetchDispatch, Mode=TwoWay}" />
+                    </Grid>
+                    <Grid Margin="16">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <ui:TextBlock Grid.Row="0"
                                       Grid.Column="0"
                                       FontTypography="Body"
                                       Text="不在某时执行"


### PR DESCRIPTION
主要是跑狗粮的时候用，激活狗粮点位的时候对点位的到达时间有要求，如果开了自动派遣，会先去领派遣之后再跑点位。我是想其他配置组可以自动领派遣，跑狗粮的时候取消自动领派遣。茶包老师你看看加个这个功能可以吗？