### PR TITLE
feat: 恰斯卡子弹识别阈值可配置化（默认0.8）

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoFight/AutoFightConfig.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/AutoFightConfig.cs
@@ -101,6 +101,13 @@ public partial class AutoFightConfig : ObservableObject
     [ObservableProperty] private int _specializedFrameIntervalMs = 50;
 
     /// <summary>
+    /// 恰斯卡子弹识别阈值（默认 0.8）。
+    /// Jaccard 相似度 * √覆盖率 低于此值时判定为"空"弹。
+    /// 值越高越容易判空（减少误报），值越低越容易识别出元素（可能误判）。
+    /// </summary>
+    [ObservableProperty] private double _chascaBulletThreshold = 0.8;
+
+    /// <summary>
     /// 桑多涅（Sandrone）重击时间序列（字符串，格式待定）。
     /// </summary>
     [ObservableProperty] private string _sandroneChargeTimeSequence = "";

--- a/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
@@ -2820,7 +2820,8 @@ public class Avatar
             var counts = new Dictionary<string, int>();
             allCounts[i] = counts;
 
-            if (bestElem < 0 || bestScore < 0.15)
+            var threshold = TaskContext.Instance().Config.AutoFightConfig.ChascaBulletThreshold;
+            if (bestElem < 0 || bestScore < threshold)
             {
                 statusChars[i] = '空';
                 otherCounts[i] = totalPixels;

--- a/BetterGenshinImpact/View/Pages/TaskSettingsPage.xaml
+++ b/BetterGenshinImpact/View/Pages/TaskSettingsPage.xaml
@@ -774,6 +774,32 @@
                                         Margin="0,0,12,0"
                                         Text="{Binding Config.AutoFightConfig.SpecializedFrameIntervalMs, Mode=TwoWay}" />
                         </Grid>
+                        <Grid Margin="0,12,0,0">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                            </Grid.RowDefinitions>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <ui:TextBlock Grid.Row="0"
+                                          Grid.Column="0"
+                                          FontTypography="Body"
+                                          Text="恰斯卡子弹识别阈值"
+                                          TextWrapping="Wrap" />
+                            <ui:TextBlock Grid.Row="1"
+                                          Grid.Column="0"
+                                          Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                          Text="Jaccard相似度×√覆盖率低于此值判空，默认0.8（越高越容易判空，越低越易识别元素）"
+                                          TextWrapping="Wrap" />
+                            <ui:TextBox Grid.Row="0"
+                                        Grid.RowSpan="2"
+                                        Grid.Column="1"
+                                        Width="60"
+                                        Margin="0,0,12,0"
+                                        Text="{Binding Config.AutoFightConfig.ChascaBulletThreshold, Mode=TwoWay}" />
+                        </Grid>
 
                         <!-- 桑多涅特化配置 -->
                         <Grid Margin="0,12,0,0">

--- a/BetterGenshinImpact/View/Pages/View/ScriptGroupConfigView.xaml
+++ b/BetterGenshinImpact/View/Pages/View/ScriptGroupConfigView.xaml
@@ -1691,6 +1691,32 @@
                                             Margin="0,0,12,0"
                                             Text="{Binding PathingConfig.AutoFightConfig.SpecializedFrameIntervalMs, Mode=TwoWay}" />
                             </Grid>
+                            <Grid Margin="0,12,0,0">
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="Auto" />
+                                </Grid.RowDefinitions>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+                                <ui:TextBlock Grid.Row="0"
+                                              Grid.Column="0"
+                                              FontTypography="Body"
+                                              Text="恰斯卡子弹识别阈值"
+                                              TextWrapping="Wrap" />
+                                <ui:TextBlock Grid.Row="1"
+                                              Grid.Column="0"
+                                              Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                              Text="Jaccard相似度×√覆盖率低于此值判空，默认0.8（越高越容易判空，越低越易识别元素）"
+                                              TextWrapping="Wrap" />
+                                <ui:TextBox Grid.Row="0"
+                                            Grid.RowSpan="2"
+                                            Grid.Column="1"
+                                            Width="60"
+                                            Margin="0,0,12,0"
+                                            Text="{Binding PathingConfig.AutoFightConfig.ChascaBulletThreshold, Mode=TwoWay}" />
+                            </Grid>
                             <!-- 桑多涅特化配置 -->
                             <Grid Margin="0,12,0,0">
                                 <Grid.RowDefinitions>


### PR DESCRIPTION
将硬编码的 Jaccard 阈值 0.15 改为配置项 ChascaBulletThreshold（默认0.8），在独立任务设置和配置组两处 UI 均添加输入框，方便用户按需调整识别灵敏度。