### PR TITLE
修复脚本启动时因游戏处于地图、F1 等多选项界面而导致的无限等待问题。

### DIFF
--- a/BetterGenshinImpact/Service/ScriptService.cs
+++ b/BetterGenshinImpact/Service/ScriptService.cs
@@ -643,6 +643,7 @@ public partial class ScriptService : IScriptService
                     var first = true;
                     var sw = Stopwatch.StartNew();
                     var loseFocusCount = 0;
+                    double lastAttemptSeconds = 0;
                     while (true)
                     {
                         if (CancellationContext.Instance.IsCancellationRequested)
@@ -667,12 +668,30 @@ public partial class ScriptService : IScriptService
                         {
                             first = false;
                             TaskControl.Logger.LogInformation("当前不在游戏主界面，等待进入主界面后执行任务...");
-                            TaskControl.Logger.LogInformation("如果你已经在游戏内的其他界面，请自行退出当前界面（ESC），或是30秒后将程序将自动尝试到入主界面，使当前任务能够继续运行！");
+                            TaskControl.Logger.LogInformation("如果你已经在游戏内的其他界面，请自行退出当前界面（ESC），或是30秒后将程序将自动尝试进入主界面，使当前任务能够继续运行！");
                         }
 
                         await Task.Delay(500);
                         if (sw.Elapsed.TotalSeconds >= 30)
                         {
+                            var totalSeconds = sw.Elapsed.TotalSeconds;
+                            if (totalSeconds - lastAttemptSeconds >= 30)
+                            {
+                                lastAttemptSeconds = totalSeconds;
+                                var retryCount = (int)((totalSeconds - 30) / 30) + 1;
+                                TaskControl.Logger.LogInformation($"尝试进入主界面（第{retryCount}次），下次尝试约30秒后...");
+
+                                var returnTask = new ReturnMainUiTask();
+                                try
+                                {
+                                    returnTask.Start(CancellationToken.None).Wait(5000);
+                                }
+                                catch (Exception ex)
+                                {
+                                    TaskControl.Logger.LogWarning($"返回主界面失败: {ex.Message}");
+                                }
+                            }
+
                             //防止自启动游戏后因为一些原因失焦，导致一直卡住
                             if (!SystemControl.IsGenshinImpactActiveByProcess())
                             {


### PR DESCRIPTION
此前，当脚本启动时若玩家正处于地图(需有传送或其他选项)
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/079eb4e6-c951-44c3-a60d-a63ede64daf4" />
F1 冒险之证界面
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/e1d67507-fa0d-4c30-8fca-65f479b4878a" />
或其他非主界面，可能会无限期等待用户手动 ESC 返回主界面，极易造成任务卡死。本次改动在等待逻辑中增加定时自动恢复机制：若 30 秒后仍未进入主界面，则自动调用 ReturnMainUiTask 尝试返回主界面，并每 30 秒重试一次，同时记录重试次数与异常信息，提升脚本的容错性与自动化程度。此外修正了日志中的错别字。